### PR TITLE
Modified Header helper

### DIFF
--- a/controllers/helper.js
+++ b/controllers/helper.js
@@ -1,16 +1,27 @@
 // Routes everything '/helper' related.
 
-exports.index = function(app){
+exports.index = function(app) {
 
-	app.get('/helper', function(req, res){
-		res.render('helper/index', {'title': 'Request Modules'});
-	});	
+    app.get('/helper', function(req, res) {
+        res.render('helper/index', {
+            'title': 'Request Modules'
+        });
+    });
 }
 
-exports.headers = function(app){
-	// Headers - Returns a JSON array of Request Headers
-	app.get('/helper/headers', function(req, res){
-		var headers = JSON.stringify(req.headers);
-		res.end(headers);
-	});
-}	
+exports.headers = function(app) {
+    // Headers - Returns a JSON array of Request Headers
+    app.get('/helper/headers', function(req, res) {
+        / If a query param 'filter' is provided, then delete the header which
+        / / does not contains the value specified in the filter
+        var filter = req.query.filter;
+        for (var item in req.headers) {
+            if (req.headers[item] != filter) {
+                delete(req.headers[item]);
+            }
+        }
+
+        var headers = JSON.stringify(req.headers);
+        res.end(headers);
+    });
+}

--- a/views/helper/index.ejs
+++ b/views/helper/index.ejs
@@ -1,15 +1,15 @@
 <% include ../layouts/header.ejs %>
-<% include ../layouts/navbar.ejs %>
-<div class="container">
-<center>
-			<h1>Helper Modules</h1>
-			<h2>These help you build useful & awesome modules.</h2>
-</center>
-<br/>
-<br/>
+    <% include ../layouts/navbar.ejs %>
+        <div class="container">
+            <center>
+                <h1>Helper Modules</h1>
+                <h2>These help you build useful & awesome modules.</h2>
+            </center>
+            <br/>
+            <br/>
 
-<h4><a href ="/helper/headers" target="_blank">Headers</a> - Returns a JSON array of Request Headers</h4>
+            <h4><a href ="/helper/headers" target="_blank">Headers</a> - Returns a JSON array of Request Headers. You can optionally provide a 'filter' query parameter and only the headers containing the value provided in filter will be returned.</h4>
 
-</div>
+        </div>
 
-<% include ../layouts/footer.ejs %>
+        <% include ../layouts/footer.ejs %>


### PR DESCRIPTION
Helper header now accepts ‘filter’ parameter. This will only return
headers that contain the value specified by the filter query param.
